### PR TITLE
Add SSN to PrimaryRequest

### DIFF
--- a/lib/experian/precise_id/primary_request.rb
+++ b/lib/experian/precise_id/primary_request.rb
@@ -28,6 +28,7 @@ module Experian
             xml.tag!('Surname', @options[:last_name])
             xml.tag!('First', @options[:first_name])
           end
+          xml.tag!('SSN', @options[:ssn]) if @options[:ssn]
           add_current_address(xml)
           add_phone_numebr(xml)
           xml.tag!('DOB', @options[:dob]) if @options[:dob]

--- a/test/precise_id/primary_request_test.rb
+++ b/test/precise_id/primary_request_test.rb
@@ -21,6 +21,11 @@ describe Experian::PreciseId::PrimaryRequest do
     assert_includes request.xml, "<DOB>1231990</DOB>"
   end
 
+  it "includes ssn if it's included" do
+    request = Experian::PreciseId::PrimaryRequest.new(params.merge({ :ssn => "999112233" }))
+    assert_includes request.xml, "<SSN>999112233</SSN>"
+  end
+
   it "includes phone number if it is provided" do
     request = Experian::PreciseId::PrimaryRequest.new(params.merge({ :phone => "12345" }))
     assert_match %r{<Phone>\s*<Number>12345</Number>\s*</Phone>}, request.xml


### PR DESCRIPTION
Added SSN as an option to PrimaryRequest. SSN isn't a required field but it is recommended by their documentation (v 01-14-2015)
