### PR TITLE
Save the node "code" attribute if the node text is blank

### DIFF
--- a/lib/experian/response.rb
+++ b/lib/experian/response.rb
@@ -77,11 +77,15 @@ module Experian
             end
           end
         else
-          response = node.text
+          response =
+            if node.text.blank?
+              node.attributes.get_attribute("code").try(:value).try(:strip).presence
+            else
+              node.text.strip
+            end
         end
         response
       end
 
   end
 end
-


### PR DESCRIPTION
1. If the node text is blank, save the code attribute if it exists and isn't blank.
2. Strip the values to remove extraneous whitespace

Here is a diff example of what the output would be with this PR. 
![screen shot 2016-12-30 at 4 36 13 pm](https://cloud.githubusercontent.com/assets/253936/21574415/9fc9da96-ceaf-11e6-8645-96dcc8903950.png)
